### PR TITLE
Add zip cli command, generate requirements.txt during scan, and add example jupyter notebook

### DIFF
--- a/src/datacustomcode/cli.py
+++ b/src/datacustomcode/cli.py
@@ -68,6 +68,35 @@ def configure(
         login_url=login_url,
     ).update_ini(profile=profile)
 
+@cli.command()
+@click.option("--profile", default="default")
+@click.option("--path", default="payload")
+@click.option("--name", default="test_pkg")
+@click.option("--version", default="0.0.1")
+@click.option("--description", default="Custom Data Transform Code")
+def zip(profile: str, path: str, name: str, version: str, description: str):
+    from datacustomcode.credentials import Credentials
+    from datacustomcode.deploy import TransformationJobMetadata, zip, zip_and_upload_directory
+
+    logger.debug("Zipping project")
+
+    metadata = TransformationJobMetadata(
+        name=name,
+        version=version,
+        description=description,
+    )
+    try:
+        credentials = Credentials.from_ini(profile=profile)
+    except KeyError:
+        click.secho(
+            f"Error: Profile {profile} not found in credentials.ini. "
+            "Run `datacustomcode configure` to create a credentialsprofile.",
+            fg="red",
+        )
+        raise click.Abort() from None
+    zip(path, metadata, credentials, name)
+
+
 
 @cli.command()
 @click.option("--profile", default="default")

--- a/src/datacustomcode/cli.py
+++ b/src/datacustomcode/cli.py
@@ -156,8 +156,10 @@ def init(directory: str):
 @click.argument("filename")
 @click.option("--config")
 @click.option("--dry-run", is_flag=True)
-def scan(filename: str, config: str, dry_run: bool):
-    from datacustomcode.scan import dc_config_json_from_file
+@click.option("--no-requirements", is_flag=True, help="Skip generating requirements.txt file")
+def scan(filename: str, config: str, dry_run: bool, no_requirements: bool):
+    from datacustomcode.scan import dc_config_json_from_file, write_requirements_file
+
 
     config_location = config or os.path.join(os.path.dirname(filename), "config.json")
     click.echo(
@@ -171,6 +173,13 @@ def scan(filename: str, config: str, dry_run: bool):
     if not dry_run:
         with open(config_location, "w") as f:
             json.dump(config_json, f, indent=2)
+
+        if not no_requirements:
+            requirements_path = write_requirements_file(filename)
+            click.echo(
+                "Generated requirements file: "
+                + click.style(requirements_path, fg="blue", bold=True)
+            )
 
 
 @cli.command()

--- a/src/datacustomcode/cli.py
+++ b/src/datacustomcode/cli.py
@@ -68,34 +68,14 @@ def configure(
         login_url=login_url,
     ).update_ini(profile=profile)
 
+
 @cli.command()
-@click.option("--profile", default="default")
-@click.option("--path", default="payload")
-@click.option("--name", default="test_pkg")
-@click.option("--version", default="0.0.1")
-@click.option("--description", default="Custom Data Transform Code")
-def zip(profile: str, path: str, name: str, version: str, description: str):
-    from datacustomcode.credentials import Credentials
-    from datacustomcode.deploy import TransformationJobMetadata, zip, zip_and_upload_directory
+@click.argument("path", default="payload")
+def zip(path: str):
+    from datacustomcode.deploy import zip
 
     logger.debug("Zipping project")
-
-    metadata = TransformationJobMetadata(
-        name=name,
-        version=version,
-        description=description,
-    )
-    try:
-        credentials = Credentials.from_ini(profile=profile)
-    except KeyError:
-        click.secho(
-            f"Error: Profile {profile} not found in credentials.ini. "
-            "Run `datacustomcode configure` to create a credentialsprofile.",
-            fg="red",
-        )
-        raise click.Abort() from None
-    zip(path, metadata, credentials, name)
-
+    zip(path)
 
 
 @cli.command()
@@ -156,10 +136,11 @@ def init(directory: str):
 @click.argument("filename")
 @click.option("--config")
 @click.option("--dry-run", is_flag=True)
-@click.option("--no-requirements", is_flag=True, help="Skip generating requirements.txt file")
+@click.option(
+    "--no-requirements", is_flag=True, help="Skip generating requirements.txt file"
+)
 def scan(filename: str, config: str, dry_run: bool, no_requirements: bool):
     from datacustomcode.scan import dc_config_json_from_file, write_requirements_file
-
 
     config_location = config or os.path.join(os.path.dirname(filename), "config.json")
     click.echo(

--- a/src/datacustomcode/deploy.py
+++ b/src/datacustomcode/deploy.py
@@ -169,23 +169,41 @@ def prepare_dependency_archive(directory: str) -> None:
         archive_file = os.path.join(archives_dir, DEPENDENCIES_ARCHIVE_NAME)
         with tarfile.open(archive_file, "w:gz") as tar:
             for file in os.listdir(temp_dir):
+                # Exclude requirements.txt from the archive
+                if file == "requirements.txt":
+                    continue
                 tar.add(os.path.join(temp_dir, file), arcname=file)
 
         logger.debug(f"Dependencies downloaded and archived to {archive_file}")
 
 
-def zip_and_upload_directory(directory: str, file_upload_url: str) -> None:
-    file_upload_url = unescape(file_upload_url)
+def zip_and_upload_directory(directory: str, name: str) -> None:
+    #   file_upload_url = unescape(file_upload_url)
 
     logger.debug(f"Zipping directory... {directory}")
-    shutil.make_archive(ZIP_FILE_NAME.rstrip(".zip"), "zip", directory)
 
-    logger.debug(f"Uploading deployment to {file_upload_url}")
-    with open(ZIP_FILE_NAME, "rb") as zip_file:
-        response = requests.put(
-            file_upload_url, data=zip_file, headers={"Content-Type": "application/zip"}
-        )
-        response.raise_for_status()
+    # Create a zip file excluding .DS_Store files
+    import zipfile
+
+    zip_filename = f"{name}.zip"
+    with zipfile.ZipFile(zip_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
+        for root, dirs, files in os.walk(directory):
+            # Skip .DS_Store files when adding to zip
+            for file in files:
+                if file != '.DS_Store':
+                    file_path = os.path.join(root, file)
+                    # Preserve relative path structure in the zip file
+                    arcname = os.path.relpath(file_path, directory)
+                    zipf.write(file_path, arcname)
+
+    logger.debug(f"Created zip file: {zip_filename} (excluding .DS_Store files)")
+
+    # logger.debug(f"Uploading deployment to {file_upload_url}")
+    # with open(ZIP_FILE_NAME, "rb") as zip_file:
+    #     response = requests.put(
+    #         file_upload_url, data=zip_file, headers={"Content-Type": "application/zip"}
+    #     )
+    #     response.raise_for_status()
 
 
 class DeploymentsResponse(BaseModel):
@@ -323,6 +341,60 @@ def create_data_transform(
     url = _join_strip_url(access_token.instance_url, DATA_TRANSFORMS_PATH)
     response = _make_api_call(url, "POST", token=access_token.access_token, json=body)
     return response
+
+def has_nonempty_requirements_file(directory: str) -> bool:
+    """
+    Check if requirements.txt exists in the given directory and has at least one non-comment line.
+    Args:
+        directory (str): The directory to check for requirements.txt.
+    Returns:
+        bool: True if requirements.txt exists and has a non-comment line, False otherwise.
+    """
+    # Look for requirements.txt in the parent directory of the given directory
+    requirements_path = os.path.join(os.path.dirname(directory), "requirements.txt")
+    print(requirements_path)
+
+    try:
+        if os.path.isfile(requirements_path):
+            #print the contents of the file
+            with open(requirements_path, "r", encoding="utf-8") as f:
+                print(f.read())
+            with open(requirements_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    # Consider non-empty if any line is not a comment (ignoring leading whitespace)
+                    if line.strip() and not line.lstrip().startswith('#'):
+                        return True
+    except Exception as e:
+        logger.error(f"Error reading requirements.txt: {e}")
+    return False
+
+
+def zip(
+    directory: str,
+    metadata: TransformationJobMetadata,
+    credentials: Credentials,
+    name: str,
+    callback=None,
+) -> AccessTokenResponse:
+    """Deploy a data transform in the DataCloud."""
+    access_token = _retrieve_access_token(credentials)
+
+    # prepare payload only if requirements.txt is non-empty
+    if has_nonempty_requirements_file(directory):
+        prepare_dependency_archive(directory)
+    else:
+        logger.info(f"Skipping dependency archive: requirements.txt is missing or empty in {directory}")
+ #   create_data_transform_config(directory)
+
+    # create deployment and upload payload
+#    deployment = create_deployment(access_token, metadata)
+    zip_and_upload_directory(directory, name)
+    #, deployment.fileUploadUrl)
+#    wait_for_deployment(access_token, metadata, callback)
+
+    # create data transform
+#   create_data_transform(directory, access_token, metadata)
+    return access_token
 
 
 def deploy_full(

--- a/src/datacustomcode/scan.py
+++ b/src/datacustomcode/scan.py
@@ -13,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import annotations
-import os
-from typing import Union, Dict, List, FrozenSet, Set
 
 import ast
+import os
 from typing import (
     Any,
+    ClassVar,
     Dict,
+    Set,
     Union,
 )
 
@@ -137,17 +138,55 @@ class ImportVisitor(ast.NodeVisitor):
     """AST Visitor that extracts external package imports from Python code."""
 
     # Standard library modules that should be excluded from requirements
-    STANDARD_LIBS = {
-        "abc", "argparse", "ast", "asyncio", "base64", "collections", "configparser",
-        "contextlib", "copy", "csv", "datetime", "enum", "functools", "glob", "hashlib",
-        "http", "importlib", "inspect", "io", "itertools", "json", "logging", "math",
-        "os", "pathlib", "pickle", "random", "re", "shutil", "site", "socket", "sqlite3",
-        "string", "subprocess", "sys", "tempfile", "threading", "time", "traceback",
-        "typing", "uuid", "warnings", "xml", "zipfile"
+    STANDARD_LIBS: ClassVar[set[str]] = {
+        "abc",
+        "argparse",
+        "ast",
+        "asyncio",
+        "base64",
+        "collections",
+        "configparser",
+        "contextlib",
+        "copy",
+        "csv",
+        "datetime",
+        "enum",
+        "functools",
+        "glob",
+        "hashlib",
+        "http",
+        "importlib",
+        "inspect",
+        "io",
+        "itertools",
+        "json",
+        "logging",
+        "math",
+        "os",
+        "pathlib",
+        "pickle",
+        "random",
+        "re",
+        "shutil",
+        "site",
+        "socket",
+        "sqlite3",
+        "string",
+        "subprocess",
+        "sys",
+        "tempfile",
+        "threading",
+        "time",
+        "traceback",
+        "typing",
+        "uuid",
+        "warnings",
+        "xml",
+        "zipfile",
     }
 
     # Additional packages to exclude from requirements.txt
-    EXCLUDED_PACKAGES = {
+    EXCLUDED_PACKAGES: ClassVar[set[str]] = {
         "datacustomcode",  # Internal package
         "pyspark",  # Provided by the runtime environment
     }
@@ -159,10 +198,12 @@ class ImportVisitor(ast.NodeVisitor):
         """Visit an import statement (e.g., import os, sys)."""
         for name in node.names:
             # Get the top-level package name
-            package = name.name.split('.')[0]
-            if (package not in self.STANDARD_LIBS and
-                    package not in self.EXCLUDED_PACKAGES and
-                    not package.startswith('_')):
+            package = name.name.split(".")[0]
+            if (
+                package not in self.STANDARD_LIBS
+                and package not in self.EXCLUDED_PACKAGES
+                and not package.startswith("_")
+            ):
                 self.imports.add(package)
         self.generic_visit(node)
 
@@ -170,10 +211,12 @@ class ImportVisitor(ast.NodeVisitor):
         """Visit a from-import statement (e.g., from os import path)."""
         if node.module is not None:
             # Get the top-level package
-            package = node.module.split('.')[0]
-            if (package not in self.STANDARD_LIBS and
-                    package not in self.EXCLUDED_PACKAGES and
-                    not package.startswith('_')):
+            package = node.module.split(".")[0]
+            if (
+                package not in self.STANDARD_LIBS
+                and package not in self.EXCLUDED_PACKAGES
+                and not package.startswith("_")
+            ):
                 self.imports.add(package)
         self.generic_visit(node)
 
@@ -188,23 +231,21 @@ def scan_file_for_imports(file_path: str) -> Set[str]:
         return visitor.imports
 
 
-def write_requirements_file(file_path: str, output_dir: str = None) -> str:
+def write_requirements_file(file_path: str) -> str:
     """
     Scan a Python file for imports and write them to requirements.txt.
 
     Args:
         file_path: Path to the Python file to scan
-        output_dir: Directory where requirements.txt should be created (defaults to parent directory)
 
     Returns:
         Path to the generated requirements.txt file
     """
     imports = scan_file_for_imports(file_path)
 
-    if not output_dir:
-        # Use the parent directory rather than same directory as the file
-        file_dir = os.path.dirname(file_path)
-        output_dir = os.path.dirname(file_dir) if file_dir else "."
+    # Use the parent directory rather than same directory as the file
+    file_dir = os.path.dirname(file_path)
+    output_dir = os.path.dirname(file_dir) if file_dir else "."
 
     requirements_path = os.path.join(output_dir, "requirements.txt")
 

--- a/src/datacustomcode/scan.py
+++ b/src/datacustomcode/scan.py
@@ -243,11 +243,10 @@ def write_requirements_file(file_path: str) -> str:
     """
     imports = scan_file_for_imports(file_path)
 
-    # Use the parent directory rather than same directory as the file
+    # Write requirements.txt in the parent directory of the Python file
     file_dir = os.path.dirname(file_path)
-    output_dir = os.path.dirname(file_dir) if file_dir else "."
-
-    requirements_path = os.path.join(output_dir, "requirements.txt")
+    parent_dir = os.path.dirname(file_dir) if file_dir else "."
+    requirements_path = os.path.join(parent_dir, "requirements.txt")
 
     # If the file exists, read existing requirements and merge with new ones
     existing_requirements = set()

--- a/src/datacustomcode/templates/account.ipynb
+++ b/src/datacustomcode/templates/account.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "253d95db-fdc6-4bbb-b75c-20b46639f2d3",
+   "id": "0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,19 +15,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "debdfc62-489b-4ca8-af1d-56c60c0d32e7",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "client = Client()  \n",
-    " \n",
-    "df = client.read_dlo(\"Account_Home__dll\")\n"
+    "client = Client()\n",
+    "\n",
+    "df = client.read_dlo(\"Account_Home__dll\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d96ad7c8-f5ba-44a7-a2ad-8597beb20cf4",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,25 +38,25 @@
     "df_upper1 = df_upper1.drop(\"KQ_ParentId__c\")\n",
     "df_upper1 = df_upper1.drop(\"KQ_Id__c\")\n",
     "\n",
-    "df_upper1.show()\n"
+    "df_upper1.show()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f823139-3a22-487f-a4a1-966c6269a708",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Save the transformed DataFrame\n",
-    "dlo_name = 'Account_Home_copy__dll'\n",
-    "client.write_to_dlo(dlo_name, df_upper1, write_mode=WriteMode.APPEND)\n"
+    "dlo_name = \"Account_Home_copy__dll\"\n",
+    "client.write_to_dlo(dlo_name, df_upper1, write_mode=WriteMode.APPEND)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "425f383b-09b4-45ee-957c-f215d7a2ccf2",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/datacustomcode/templates/account.ipynb
+++ b/src/datacustomcode/templates/account.ipynb
@@ -1,0 +1,86 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "253d95db-fdc6-4bbb-b75c-20b46639f2d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datacustomcode.client import Client\n",
+    "from datacustomcode.io.writer.base import WriteMode\n",
+    "from pyspark.sql.functions import col, upper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "debdfc62-489b-4ca8-af1d-56c60c0d32e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = Client()  \n",
+    " \n",
+    "df = client.read_dlo(\"Account_Home__dll\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d96ad7c8-f5ba-44a7-a2ad-8597beb20cf4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Perform transformations on the DataFrame\n",
+    "df_upper1 = df.withColumn(\"Description__c\", upper(col(\"Description__c\")))\n",
+    "\n",
+    "# Drop specific columns related to relationships\n",
+    "df_upper1 = df_upper1.drop(\"KQ_ParentId__c\")\n",
+    "df_upper1 = df_upper1.drop(\"KQ_Id__c\")\n",
+    "\n",
+    "df_upper1.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f823139-3a22-487f-a4a1-966c6269a708",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save the transformed DataFrame\n",
+    "dlo_name = 'Account_Home_copy__dll'\n",
+    "client.write_to_dlo(dlo_name, df_upper1, write_mode=WriteMode.APPEND)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "425f383b-09b4-45ee-957c-f215d7a2ccf2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -11,6 +11,8 @@ from datacustomcode.scan import (
     DataAccessLayerCalls,
     dc_config_json_from_file,
     scan_file,
+    scan_file_for_imports,
+    write_requirements_file,
 )
 
 
@@ -422,3 +424,130 @@ def test_real_world_example():
         assert config["permissions"]["write"]["dlo"] == ["customer_data_enriched"]
     finally:
         os.unlink(temp_path)
+
+
+class TestRequirementsFile:
+    def test_scan_file_for_imports(self):
+        """Test scanning a file for external package imports."""
+        content = textwrap.dedent(
+            """
+            import pandas as pd
+            import numpy as np
+            from sklearn.linear_model import LinearRegression
+            import os  # Standard library
+            import sys  # Standard library
+            from datacustomcode.client import Client  # Internal package
+            """
+        )
+        temp_path = create_test_script(content)
+        try:
+            imports = scan_file_for_imports(temp_path)
+            assert "pandas" in imports
+            assert "numpy" in imports
+            assert "sklearn" in imports
+            assert "os" not in imports  # Standard library
+            assert "sys" not in imports  # Standard library
+            assert "datacustomcode" not in imports  # Internal package
+        finally:
+            os.unlink(temp_path)
+
+    def test_write_requirements_file_new(self):
+        """Test writing a new requirements.txt file."""
+        content = textwrap.dedent(
+            """
+            import pandas as pd
+            import numpy as np
+            """
+        )
+        temp_path = create_test_script(content)
+        try:
+            requirements_path = write_requirements_file(temp_path)
+            assert os.path.exists(requirements_path)
+
+            with open(requirements_path, "r") as f:
+                requirements = {line.strip() for line in f}
+
+            assert "pandas" in requirements
+            assert "numpy" in requirements
+        finally:
+            os.unlink(temp_path)
+            if os.path.exists(requirements_path):
+                os.unlink(requirements_path)
+
+    def test_write_requirements_file_merge(self):
+        """Test merging with existing requirements.txt file."""
+        # First create an existing requirements.txt
+        temp_dir = tempfile.mkdtemp()
+        existing_requirements = os.path.join(temp_dir, "requirements.txt")
+        with open(existing_requirements, "w") as f:
+            f.write("pandas\nnumpy\n")
+
+        # Create a new Python file with additional imports
+        content = textwrap.dedent(
+            """
+            import pandas as pd
+            import numpy as np
+            import scipy
+            import matplotlib
+            """
+        )
+        temp_path = create_test_script(content)
+        try:
+            requirements_path = write_requirements_file(temp_path)
+            assert os.path.exists(requirements_path)
+
+            with open(requirements_path, "r") as f:
+                requirements = {line.strip() for line in f}
+
+            # Check that both existing and new requirements are present
+            assert "pandas" in requirements
+            assert "numpy" in requirements
+            assert "scipy" in requirements
+            assert "matplotlib" in requirements
+        finally:
+            os.unlink(temp_path)
+            if os.path.exists(requirements_path):
+                os.unlink(requirements_path)
+            if os.path.exists(existing_requirements):
+                os.unlink(existing_requirements)
+            os.rmdir(temp_dir)
+
+    def test_standard_library_exclusion(self):
+        """Test that standard library imports are excluded."""
+        content = textwrap.dedent(
+            """
+            import os
+            import sys
+            import json
+            import datetime
+            import pandas as pd
+            """
+        )
+        temp_path = create_test_script(content)
+        try:
+            imports = scan_file_for_imports(temp_path)
+            assert "pandas" in imports
+            assert "os" not in imports
+            assert "sys" not in imports
+            assert "json" not in imports
+            assert "datetime" not in imports
+        finally:
+            os.unlink(temp_path)
+
+    def test_excluded_packages(self):
+        """Test that excluded packages are not included in requirements."""
+        content = textwrap.dedent(
+            """
+            import datacustomcode
+            import pyspark
+            import pandas as pd
+            """
+        )
+        temp_path = create_test_script(content)
+        try:
+            imports = scan_file_for_imports(temp_path)
+            assert "pandas" in imports
+            assert "datacustomcode" not in imports
+            assert "pyspark" not in imports
+        finally:
+            os.unlink(temp_path)

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -453,16 +453,28 @@ class TestRequirementsFile:
 
     def test_write_requirements_file_new(self):
         """Test writing a new requirements.txt file."""
+        # Create a temporary directory structure
+        temp_dir = tempfile.mkdtemp()
+        script_dir = os.path.join(temp_dir, "script_dir")
+        os.makedirs(script_dir)
+
         content = textwrap.dedent(
             """
             import pandas as pd
             import numpy as np
             """
         )
-        temp_path = create_test_script(content)
+        temp_path = os.path.join(script_dir, "test_script.py")
+        with open(temp_path, "w") as f:
+            f.write(content)
+
+        requirements_path = None
         try:
             requirements_path = write_requirements_file(temp_path)
             assert os.path.exists(requirements_path)
+            assert (
+                os.path.dirname(requirements_path) == temp_dir
+            )  # Should be in parent directory
 
             with open(requirements_path, "r") as f:
                 requirements = {line.strip() for line in f}
@@ -470,14 +482,21 @@ class TestRequirementsFile:
             assert "pandas" in requirements
             assert "numpy" in requirements
         finally:
-            os.unlink(temp_path)
-            if os.path.exists(requirements_path):
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+            if requirements_path and os.path.exists(requirements_path):
                 os.unlink(requirements_path)
+            os.rmdir(script_dir)
+            os.rmdir(temp_dir)
 
     def test_write_requirements_file_merge(self):
         """Test merging with existing requirements.txt file."""
-        # First create an existing requirements.txt
+        # Create a temporary directory structure
         temp_dir = tempfile.mkdtemp()
+        script_dir = os.path.join(temp_dir, "script_dir")
+        os.makedirs(script_dir)
+
+        # Create existing requirements.txt in parent directory
         existing_requirements = os.path.join(temp_dir, "requirements.txt")
         with open(existing_requirements, "w") as f:
             f.write("pandas\nnumpy\n")
@@ -491,10 +510,17 @@ class TestRequirementsFile:
             import matplotlib
             """
         )
-        temp_path = create_test_script(content)
+        temp_path = os.path.join(script_dir, "test_script.py")
+        with open(temp_path, "w") as f:
+            f.write(content)
+
+        requirements_path = None
         try:
             requirements_path = write_requirements_file(temp_path)
             assert os.path.exists(requirements_path)
+            assert (
+                os.path.dirname(requirements_path) == temp_dir
+            )  # Should be in parent directory
 
             with open(requirements_path, "r") as f:
                 requirements = {line.strip() for line in f}
@@ -505,11 +531,13 @@ class TestRequirementsFile:
             assert "scipy" in requirements
             assert "matplotlib" in requirements
         finally:
-            os.unlink(temp_path)
-            if os.path.exists(requirements_path):
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+            if requirements_path and os.path.exists(requirements_path):
                 os.unlink(requirements_path)
             if os.path.exists(existing_requirements):
                 os.unlink(existing_requirements)
+            os.rmdir(script_dir)
             os.rmdir(temp_dir)
 
     def test_standard_library_exclusion(self):


### PR DESCRIPTION
- Users can now run `datacustomcode zip` or `datacustomcode zip payload` to zip up their package for deployment.  This is needed because our UI expects you to have a zip ready, and we want customers using docker to build their zips to avoid platform/architecture mismatches between their machines and DataCloud compute
- When running `datacustomcode scan ./payload/entrypoint.py`, requirement.txt is also updated.  This catches a scenario where you've pip installed into the venv you're working in, but forgotten to add it to requirements.txt (which drives our zip process).
- Added jupyter notebook example to provide a better starting point once jupyter lab is started