### PR TITLE
Remove beta labeling now that custom code is GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Data Cloud Custom Code SDK (BETA)
+# Data Cloud Custom Code SDK
 
 This package provides a development kit for creating custom data transformations in [Data Cloud](https://www.salesforce.com/data/). It allows you to write your own data processing logic in Python while leveraging Data Cloud's infrastructure for data access and running data transformations, mapping execution into Data Cloud data structures like [Data Model Objects](https://help.salesforce.com/s/articleView?id=data.c360_a_data_model_objects.htm&type=5) and [Data Lake Objects](https://help.salesforce.com/s/articleView?id=sf.c360_a_data_lake_objects.htm&language=en_US&type=5).
 
@@ -11,7 +11,7 @@ Use of this project with Salesforce is subject to the [TERMS OF USE](./TERMS_OF_
 - **Python 3.11 only** (currently supported version - if your system version is different, we recommend using [pyenv](https://github.com/pyenv/pyenv) to configure 3.11)
 - JDK 17
 - Docker support like [Docker Desktop](https://docs.docker.com/desktop/)
-- A salesforce org with some DLOs or DMOs with data and this feature enabled (it is not GA)
+- A salesforce org with some DLOs or DMOs with data and this feature enabled
 - **One of the following** for authentication:
   - A Salesforce org already authenticated via the [Salesforce CLI](https://developer.salesforce.com/tools/salesforcecli)
     (simplest — no External Client App needed)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["poetry-core>=2.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
 [project]
 authors = []
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "Operating System :: Unix",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",


### PR DESCRIPTION
## What & why
The Data Cloud Custom Code SDK is now generally available, but several `beta` references remain in the package and its PyPI/GitHub-rendered docs. This removes them:

- **README.md** — drop `(BETA)` from the title and the `it is not GA` prerequisite note.
- **pyproject.toml** — bump the PyPI classifier from `Development Status :: 4 - Beta` to `5 - Production/Stable` so the PyPI listing no longer shows a beta label.

## Notes
- The `datacustomcode` CLI command docs are intentionally left unchanged — that is the CLI this pip package actually ships (`[tool.poetry.scripts]`).