### PR TITLE
Support einstein predict for script in public SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,56 @@ datacustomcode run ./payload/entrypoint.py --sf-cli-org myorg
 ```
 
 
+## Testing Einstein Predictions
+
+You can use AI models configured in Einstein Studio to score your data while
+transforming it. As with the LLM Gateway, there are two flavors: a one-shot
+scalar call (`client.einstein_predict`) and a per-row column helper
+(`einstein_predict_col`). Below is a sample code example:
+
+```
+from datacustomcode.client import Client, einstein_predict_col
+from datacustomcode.einstein_predictions.types import PredictionType
+
+
+def main():
+  client = Client()
+  df = client.read_dlo("Input__dll")
+  # einstein_predict_col returns a struct
+  # {status, response, error_code, error_message} per row, so per-row
+  # failures don't abort the Spark job. `response` is the prediction
+  # payload as a JSON string. Pick the field you want with [].
+  df_scored = df.withColumn(
+    "prediction__c",
+    einstein_predict_col(
+        "my_regression_model",  # An AI model in your org
+        PredictionType.REGRESSION,
+        {"square_feet": col("square_feet__c"), "beds": col("beds__c")},
+    )["response"],
+  )
+
+  dlo_name = "Output_dll"
+  client.write_to_dlo(dlo_name, df_scored, write_mode=WriteMode.APPEND)
+
+  # One-shot scalar prediction returns the response payload as a dict
+  prediction = client.einstein_predict(
+    "my_regression_model",
+    PredictionType.REGRESSION,
+    {"square_feet": 1800, "beds": 3},
+  )
+
+if __name__ == "__main__":
+  main()
+```
+
+Testing this code locally uses the same External Client App setup described in
+[Testing LLM Gateway](#testing-llm-gateway). Once your `myorg` alias is set up,
+run:
+```
+datacustomcode run ./payload/entrypoint.py --sf-cli-org myorg
+```
+
+
 ## Docker usage
 
 The SDK provides Docker-based development options that allow you to test your code in an environment that closely resembles Data Cloud's execution environment.

--- a/src/datacustomcode/__init__.py
+++ b/src/datacustomcode/__init__.py
@@ -17,10 +17,13 @@ __all__ = [
     "AuthType",
     "Client",
     "Credentials",
+    "DefaultSparkEinsteinPredictions",
     "DefaultSparkLLMGateway",
     "PrintDataCloudWriter",
     "QueryAPIDataCloudReader",
+    "SparkEinsteinPredictions",
     "SparkLLMGateway",
+    "einstein_predict_col",
     "llm_gateway_generate_text_col",
 ]
 
@@ -59,4 +62,16 @@ def __getattr__(name: str):
         from datacustomcode.client import llm_gateway_generate_text_col
 
         return llm_gateway_generate_text_col
+    elif name == "SparkEinsteinPredictions":
+        from datacustomcode.einstein_predictions import SparkEinsteinPredictions
+
+        return SparkEinsteinPredictions
+    elif name == "DefaultSparkEinsteinPredictions":
+        from datacustomcode.einstein_predictions import DefaultSparkEinsteinPredictions
+
+        return DefaultSparkEinsteinPredictions
+    elif name == "einstein_predict_col":
+        from datacustomcode.client import einstein_predict_col
+
+        return einstein_predict_col
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/datacustomcode/client.py
+++ b/src/datacustomcode/client.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
+    Any,
     ClassVar,
     Dict,
     Optional,
@@ -24,6 +25,7 @@ from typing import (
 )
 
 from datacustomcode.config import config
+from datacustomcode.einstein_predictions_config import spark_einstein_predictions_config
 from datacustomcode.file.path.default import DefaultFindFilePath
 from datacustomcode.io.reader.base import BaseDataCloudReader
 from datacustomcode.llm_gateway_config import spark_llm_gateway_config
@@ -34,6 +36,8 @@ if TYPE_CHECKING:
 
     from pyspark.sql import Column, DataFrame as PySparkDataFrame
 
+    from datacustomcode.einstein_predictions.spark_base import SparkEinsteinPredictions
+    from datacustomcode.einstein_predictions.types import PredictionType
     from datacustomcode.io.reader.base import BaseDataCloudReader
     from datacustomcode.io.writer.base import BaseDataCloudWriter, WriteMode
     from datacustomcode.llm_gateway.spark_base import SparkLLMGateway
@@ -99,6 +103,70 @@ def llm_gateway_generate_text_col(
     return gateway.llm_gateway_generate_text_col(template, values, model_id=model_id)
 
 
+def _build_spark_einstein_predictions() -> "SparkEinsteinPredictions":
+    """Instantiate the SDK-configured :class:`SparkEinsteinPredictions`.
+
+    Raises:
+        RuntimeError: If no ``spark_einstein_predictions_config`` has been loaded.
+    """
+    cfg = spark_einstein_predictions_config.spark_einstein_predictions_config
+    if cfg is None:
+        raise RuntimeError(
+            "spark_einstein_predictions_config is not configured. Add a "
+            "'spark_einstein_predictions_config' section to config.yaml."
+        )
+    return cfg.to_object()
+
+
+def einstein_predict_col(
+    model_api_name: str,
+    prediction_type: "PredictionType",
+    features: Dict[str, "Column"],
+    settings: Optional[Dict[str, Any]] = None,
+) -> "Column":
+    """Build a Spark Column that runs an Einstein prediction per row.
+
+    The returned Column yields a struct ``{status, response, error_code,
+    error_message}`` for each row. Use ``[...]`` (or ``getField``) to pick the
+    field you want, e.g. ``einstein_predict_col(...)["response"]``. ``response``
+    holds the prediction response payload as a JSON string. Per-row failures
+    populate ``status`` / ``error_code`` / ``error_message`` so a single bad row
+    does not abort the whole Spark job.
+
+    Example:
+
+        >>> from datacustomcode.einstein_predictions.types import PredictionType
+        >>> result = einstein_predict_col(
+        ...     "my_regression_model",
+        ...     PredictionType.REGRESSION,
+        ...     {"square_feet": col("square_feet__c"), "beds": col("beds__c")},
+        ... )
+        >>> df.withColumn("prediction__c", result["response"])
+        >>> # …or keep the struct around and inspect failures:
+        >>> df.withColumn("pred", result).select(
+        ...     "pred.status", "pred.response", "pred.error_message"
+        ... )
+
+    Args:
+        model_api_name: API name of the Einstein model to invoke.
+        prediction_type: The :class:`PredictionType` of the model.
+        features: A mapping from model feature column name to a Spark ``Column``
+            supplying that feature's per-row value.
+        settings: Optional prediction settings forwarded to the model.
+
+    Returns:
+        A Spark ``Column`` of ``StructType`` with fields ``status``,
+        ``response``, ``error_code``, and ``error_message`` (all nullable
+        strings). On success, ``status == "SUCCESS"`` and ``response`` holds
+        the JSON-serialized prediction payload; on failure, ``status ==
+        "ERROR"`` and the ``error_*`` fields carry diagnostic detail.
+    """
+    predictions = Client()._get_spark_einstein_predictions()
+    return predictions.einstein_predict_col(
+        model_api_name, prediction_type, features, settings=settings
+    )
+
+
 class DataCloudObjectType(Enum):
     DLO = "dlo"
     DMO = "dmo"
@@ -158,6 +226,8 @@ class Client:
         reader: A custom reader to use for reading Data Cloud objects.
         writer: A custom writer to use for writing Data Cloud objects.
         spark_llm_gateway: Optional custom :class:`SparkLLMGateway`.
+        spark_einstein_predictions: Optional custom
+            :class:`SparkEinsteinPredictions`.
 
     Example:
     >>> client = Client()
@@ -172,6 +242,7 @@ class Client:
     _writer: BaseDataCloudWriter
     _file: DefaultFindFilePath
     _spark_llm_gateway: Optional[SparkLLMGateway]
+    _spark_einstein_predictions: Optional[SparkEinsteinPredictions]
     _data_layer_history: dict[DataCloudObjectType, set[str]]
     _code_type: str
 
@@ -181,12 +252,14 @@ class Client:
         writer: Optional[BaseDataCloudWriter] = None,
         spark_provider: Optional[BaseSparkSessionProvider] = None,
         spark_llm_gateway: Optional[SparkLLMGateway] = None,
+        spark_einstein_predictions: Optional[SparkEinsteinPredictions] = None,
         code_type: str = "script",
     ) -> Client:
 
         if cls._instance is None:
             cls._instance = super().__new__(cls)
             cls._instance._spark_llm_gateway = spark_llm_gateway
+            cls._instance._spark_einstein_predictions = spark_einstein_predictions
             # Initialize Readers and Writers from config
             # and/or provided reader and writer
             if reader is None or writer is None:
@@ -357,6 +430,49 @@ class Client:
         if self._spark_llm_gateway is None:
             self._spark_llm_gateway = _build_spark_llm_gateway()
         return self._spark_llm_gateway
+
+    def einstein_predict(
+        self,
+        model_api_name: str,
+        prediction_type: "PredictionType",
+        features: Dict[str, Any],
+        settings: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Issue a one-shot Einstein prediction. This is the scalar counterpart
+        to :func:`einstein_predict_col`: it runs **once** — not per row. Use the
+        column helper method instead when you want to fan a prediction out
+        across every row of a DataFrame.
+
+        Example:
+
+            >>> from datacustomcode.einstein_predictions.types import PredictionType
+            >>> response = Client().einstein_predict(
+            ...     "my_regression_model",
+            ...     PredictionType.REGRESSION,
+            ...     {"square_feet": 1800, "beds": 3},
+            ... )
+
+        Args:
+            model_api_name: API name of the Einstein model to invoke.
+            prediction_type: The :class:`PredictionType` of the model.
+            features: A mapping from model feature column name to a single
+                scalar value (``str`` / ``float`` / ``bool``).
+            settings: Optional prediction settings forwarded to the model.
+
+        Returns:
+            The prediction response payload as a plain Python ``dict``.
+
+        Raises:
+            EinsteinPredictionsCallError: If the prediction call fails.
+        """
+        return self._get_spark_einstein_predictions().einstein_predict(
+            model_api_name, prediction_type, features, settings=settings
+        )
+
+    def _get_spark_einstein_predictions(self) -> SparkEinsteinPredictions:
+        if self._spark_einstein_predictions is None:
+            self._spark_einstein_predictions = _build_spark_einstein_predictions()
+        return self._spark_einstein_predictions
 
     def _validate_data_layer_history_does_not_contain(
         self, data_cloud_object_type: DataCloudObjectType

--- a/src/datacustomcode/config.yaml
+++ b/src/datacustomcode/config.yaml
@@ -24,6 +24,9 @@ einstein_predictions_config:
   options:
     credentials_profile: default
 
+spark_einstein_predictions_config:
+  type_config_name: DefaultSparkEinsteinPredictions
+
 llm_gateway_config:
   type_config_name: DefaultLLMGateway
   options:

--- a/src/datacustomcode/einstein_predictions/errors.py
+++ b/src/datacustomcode/einstein_predictions/errors.py
@@ -12,19 +12,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Exceptions raised by Einstein Predictions implementations."""
 
-from datacustomcode.einstein_predictions.base import EinsteinPredictions
-from datacustomcode.einstein_predictions.errors import EinsteinPredictionsCallError
-from datacustomcode.einstein_predictions.impl.default import DefaultEinsteinPredictions
-from datacustomcode.einstein_predictions.spark_base import SparkEinsteinPredictions
-from datacustomcode.einstein_predictions.spark_default import (
-    DefaultSparkEinsteinPredictions,
-)
+from __future__ import annotations
 
-__all__ = [
-    "DefaultEinsteinPredictions",
-    "DefaultSparkEinsteinPredictions",
-    "EinsteinPredictions",
-    "EinsteinPredictionsCallError",
-    "SparkEinsteinPredictions",
-]
+from typing import Optional
+
+
+class EinsteinPredictionsCallError(RuntimeError):
+    """Raised when an Einstein Predictions call returns an error."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: Optional[object] = None,
+        error_code: Optional[str] = None,
+        error_message: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.error_code = error_code
+        self.error_message = error_message

--- a/src/datacustomcode/einstein_predictions/spark_base.py
+++ b/src/datacustomcode/einstein_predictions/spark_base.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2025, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Optional,
+)
+
+from datacustomcode.einstein_predictions.types import PredictionType
+from datacustomcode.mixin import UserExtendableNamedConfigMixin
+
+if TYPE_CHECKING:
+    from pyspark.sql import Column
+
+
+class SparkEinsteinPredictions(ABC, UserExtendableNamedConfigMixin):
+    CONFIG_NAME: str
+
+    def __init__(self, **kwargs: Any) -> None:
+        pass
+
+    @abstractmethod
+    def einstein_predict(
+        self,
+        model_api_name: str,
+        prediction_type: PredictionType,
+        features: Dict[str, Any],
+        settings: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Issue a one-shot Einstein prediction and return the response data.
+
+        ``features`` maps each model feature column name to a single scalar
+        value (``str``/``float``/``bool``). The value is wrapped into a
+        single-element prediction column of the appropriate type.
+        """
+
+    @abstractmethod
+    def einstein_predict_col(
+        self,
+        model_api_name: str,
+        prediction_type: PredictionType,
+        features: Dict[str, "Column"],
+        settings: Optional[Dict[str, Any]] = None,
+    ) -> "Column":
+        """Build a Spark ``Column`` that invokes Einstein predict per row and
+        yields a struct ``{status, response, error_code, error_message}``.
+
+        ``features`` maps each model feature column name to a Spark ``Column``
+        supplying that feature's per-row value. Select an individual field,
+        e.g. ``einstein_predict_col(...)["response"]``. ``response`` holds the
+        prediction response payload as a JSON string. Returning a struct means
+        a single failing row leaves the rest of the DataFrame intact — callers
+        can inspect ``status`` / ``error_code`` per row instead of having the
+        Spark job abort.
+        """

--- a/src/datacustomcode/einstein_predictions/spark_base.py
+++ b/src/datacustomcode/einstein_predictions/spark_base.py
@@ -22,11 +22,12 @@ from typing import (
     Optional,
 )
 
-from datacustomcode.einstein_predictions.types import PredictionType
 from datacustomcode.mixin import UserExtendableNamedConfigMixin
 
 if TYPE_CHECKING:
     from pyspark.sql import Column
+
+    from datacustomcode.einstein_predictions.types import PredictionType
 
 
 class SparkEinsteinPredictions(ABC, UserExtendableNamedConfigMixin):

--- a/src/datacustomcode/einstein_predictions/spark_default.py
+++ b/src/datacustomcode/einstein_predictions/spark_default.py
@@ -159,8 +159,7 @@ def _build_request(
     settings: Optional[Dict[str, Any]],
 ) -> PredictionRequest:
     prediction_columns = [
-        _feature_to_prediction_column(name, value)
-        for name, value in features.items()
+        _feature_to_prediction_column(name, value) for name, value in features.items()
     ]
     return PredictionRequest(
         prediction_type=prediction_type,

--- a/src/datacustomcode/einstein_predictions/spark_default.py
+++ b/src/datacustomcode/einstein_predictions/spark_default.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2025, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import json
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Optional,
+)
+
+from datacustomcode.einstein_predictions.spark_base import SparkEinsteinPredictions
+from datacustomcode.einstein_predictions.types import (
+    PredictionColumn,
+    PredictionRequest,
+    PredictionType,
+)
+
+if TYPE_CHECKING:
+    from pyspark.sql import Column
+
+    from datacustomcode.einstein_predictions.base import EinsteinPredictions
+    from datacustomcode.einstein_predictions.types import PredictionResponse
+
+
+_STATUS_SUCCESS = "SUCCESS"
+_STATUS_ERROR = "ERROR"
+
+
+class DefaultSparkEinsteinPredictions(SparkEinsteinPredictions):
+
+    CONFIG_NAME = "DefaultSparkEinsteinPredictions"
+
+    def __init__(
+        self,
+        einstein_predictions: Optional["EinsteinPredictions"] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        if einstein_predictions is None:
+            einstein_predictions = _build_underlying_predictions()
+        self._einstein_predictions: "EinsteinPredictions" = einstein_predictions
+
+    def einstein_predict(
+        self,
+        model_api_name: str,
+        prediction_type: PredictionType,
+        features: Dict[str, Any],
+        settings: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        return _invoke_predictions(
+            self._einstein_predictions,
+            model_api_name,
+            prediction_type,
+            features,
+            settings,
+        )
+
+    def einstein_predict_col(
+        self,
+        model_api_name: str,
+        prediction_type: PredictionType,
+        features: Dict[str, "Column"],
+        settings: Optional[Dict[str, Any]] = None,
+    ) -> "Column":
+        """Build a per-row UDF that returns a struct ``{status, response,
+        error_code, error_message}`` so per-row failures do not abort the
+        Spark job. Callers select the field they want, e.g.
+        ``einstein_predict_col(...)["response"]``. ``response`` carries the
+        prediction response payload serialized as a JSON string.
+        """
+        from pyspark.sql.functions import struct, udf
+        from pyspark.sql.types import (
+            StringType,
+            StructField,
+            StructType,
+        )
+
+        feature_names = list(features.keys())
+        values_col = struct(*[features[name].alias(name) for name in feature_names])
+
+        predictions = self._einstein_predictions
+        result_schema = StructType(
+            [
+                StructField("status", StringType(), True),
+                StructField("response", StringType(), True),
+                StructField("error_code", StringType(), True),
+                StructField("error_message", StringType(), True),
+            ]
+        )
+
+        def _predict(values_row: Any) -> Dict[str, Optional[str]]:
+            if values_row is None:
+                return {
+                    "status": _STATUS_ERROR,
+                    "response": None,
+                    "error_code": None,
+                    "error_message": "features column was null for this row",
+                }
+            row_features = (
+                values_row.asDict()
+                if hasattr(values_row, "asDict")
+                else dict(values_row)
+            )
+            return _invoke_predictions_as_struct(
+                predictions,
+                model_api_name,
+                prediction_type,
+                row_features,
+                settings,
+            )
+
+        return udf(_predict, result_schema)(values_col)
+
+
+def _build_underlying_predictions() -> "EinsteinPredictions":
+    from datacustomcode.einstein_predictions_config import einstein_predictions_config
+
+    cfg = einstein_predictions_config.einstein_predictions_config
+    if cfg is None:
+        raise RuntimeError(
+            "einstein_predictions_config is not configured. Add an "
+            "'einstein_predictions_config' section to config.yaml."
+        )
+    return cfg.to_object()
+
+
+def _feature_to_prediction_column(name: str, value: Any) -> PredictionColumn:
+    """Wrap a single scalar feature value into a one-element prediction column.
+
+    The value's Python type selects the prediction column value type. ``bool``
+    is checked before ``int``/``float`` because ``bool`` is a subclass of
+    ``int`` in Python.
+    """
+    if isinstance(value, bool):
+        return PredictionColumn(column_name=name, boolean_values=[value])
+    if isinstance(value, (int, float)):
+        return PredictionColumn(column_name=name, double_values=[float(value)])
+    return PredictionColumn(column_name=name, string_values=[str(value)])
+
+
+def _build_request(
+    model_api_name: str,
+    prediction_type: PredictionType,
+    features: Dict[str, Any],
+    settings: Optional[Dict[str, Any]],
+) -> PredictionRequest:
+    prediction_columns = [
+        _feature_to_prediction_column(name, value)
+        for name, value in features.items()
+    ]
+    return PredictionRequest(
+        prediction_type=prediction_type,
+        model_api_name=model_api_name,
+        prediction_columns=prediction_columns,
+        settings=settings,
+    )
+
+
+def _call_predictions(
+    predictions: "EinsteinPredictions",
+    model_api_name: str,
+    prediction_type: PredictionType,
+    features: Dict[str, Any],
+    settings: Optional[Dict[str, Any]],
+) -> "PredictionResponse":
+    """Build the request and dispatch it to the underlying predictions resource."""
+    request = _build_request(model_api_name, prediction_type, features, settings)
+    return predictions.predict(request)
+
+
+def _invoke_predictions(
+    predictions: "EinsteinPredictions",
+    model_api_name: str,
+    prediction_type: PredictionType,
+    features: Dict[str, Any],
+    settings: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    from datacustomcode.einstein_predictions.errors import EinsteinPredictionsCallError
+
+    response = _call_predictions(
+        predictions, model_api_name, prediction_type, features, settings
+    )
+    if not response.is_success:
+        error_code = _extract_error_code(response)
+        raise EinsteinPredictionsCallError(
+            f"Einstein Predictions call failed: "
+            f"status_code={response.status_code}, "
+            f"error_code={error_code!r}, message={response.data!r}",
+            status=response.status_code,
+            error_code=error_code,
+            error_message=str(response.data) if response.data else None,
+        )
+    return response.data or {}
+
+
+def _invoke_predictions_as_struct(
+    predictions: "EinsteinPredictions",
+    model_api_name: str,
+    prediction_type: PredictionType,
+    features: Dict[str, Any],
+    settings: Optional[Dict[str, Any]],
+) -> Dict[str, Optional[str]]:
+    response = _call_predictions(
+        predictions, model_api_name, prediction_type, features, settings
+    )
+    if not response.is_success:
+        return {
+            "status": _STATUS_ERROR,
+            "response": None,
+            "error_code": _extract_error_code(response),
+            "error_message": str(response.data) if response.data else None,
+        }
+    return {
+        "status": _STATUS_SUCCESS,
+        "response": json.dumps(response.data) if response.data is not None else None,
+        "error_code": None,
+        "error_message": None,
+    }
+
+
+def _extract_error_code(response: "PredictionResponse") -> Optional[str]:
+    if response.data:
+        error_code = response.data.get("errorCode")
+        if error_code is not None:
+            return str(error_code)
+    return None

--- a/src/datacustomcode/einstein_predictions_config.py
+++ b/src/datacustomcode/einstein_predictions_config.py
@@ -21,11 +21,17 @@ from typing import (
     Union,
 )
 
-from datacustomcode.common_config import BaseConfig, default_config_file
+from datacustomcode.common_config import (
+    BaseConfig,
+    BaseObjectConfig,
+    default_config_file,
+)
 from datacustomcode.einstein_platform_config import CredentialsObjectConfig
 from datacustomcode.einstein_predictions.base import EinsteinPredictions
+from datacustomcode.einstein_predictions.spark_base import SparkEinsteinPredictions
 
 _E = TypeVar("_E", bound=EinsteinPredictions)
+_S = TypeVar("_S", bound=SparkEinsteinPredictions)
 
 
 class EinsteinPredictionsObjectConfig(CredentialsObjectConfig[_E], Generic[_E]):
@@ -54,6 +60,44 @@ class EinsteinPredictionsConfig(BaseConfig):
         return self
 
 
+class SparkEinsteinPredictionsObjectConfig(BaseObjectConfig, Generic[_S]):
+    type_to_create: ClassVar[Type[SparkEinsteinPredictions]] = SparkEinsteinPredictions  # type: ignore[type-abstract]
+
+    def to_object(self) -> SparkEinsteinPredictions:
+        type_ = self.type_to_create.subclass_from_config_name(self.type_config_name)
+        return type_(**self.options)
+
+
+class SparkEinsteinPredictionsConfig(BaseConfig):
+    spark_einstein_predictions_config: Union[
+        SparkEinsteinPredictionsObjectConfig[SparkEinsteinPredictions], None
+    ] = None
+
+    def update(
+        self, other: "SparkEinsteinPredictionsConfig"
+    ) -> "SparkEinsteinPredictionsConfig":
+        def merge(
+            config_a: Union[SparkEinsteinPredictionsObjectConfig, None],
+            config_b: Union[SparkEinsteinPredictionsObjectConfig, None],
+        ) -> Union[SparkEinsteinPredictionsObjectConfig, None]:
+            if config_a is not None and config_a.force:
+                return config_a
+            if config_b:
+                return config_b
+            return config_a
+
+        self.spark_einstein_predictions_config = merge(
+            self.spark_einstein_predictions_config,
+            other.spark_einstein_predictions_config,
+        )
+        return self
+
+
 # Global Einstein Predictions config instance
 einstein_predictions_config = EinsteinPredictionsConfig()
 einstein_predictions_config.load(default_config_file())
+
+
+# Global Spark Einstein Predictions config instance
+spark_einstein_predictions_config = SparkEinsteinPredictionsConfig()
+spark_einstein_predictions_config.load(default_config_file())

--- a/src/datacustomcode/templates/script/payload/entrypoint.py
+++ b/src/datacustomcode/templates/script/payload/entrypoint.py
@@ -38,6 +38,23 @@ def main():
         >>> generated_text = client.llm_gateway_generate_text(
         ...     prompt, model_id
         ... )
+
+    You can also score rows with an Einstein Studio model. The per-row helper
+    returns the same ``{status, response, error_code, error_message}`` struct,
+    where ``response`` is the prediction payload as a JSON string.
+
+    Example:
+
+        >>> from datacustomcode.client import einstein_predict_col
+        >>> from datacustomcode.einstein_predictions.types import PredictionType
+            df_scored = df.withColumn(
+            ...     "prediction__c",
+            ...     einstein_predict_col(
+            ...         "my_regression_model",
+            ...         PredictionType.REGRESSION,
+            ...         {"beds": col("beds__c"), "baths": col("baths__c")},
+            ...     )["response"],
+            ... )
     """
 
     # Drop specific columns related to relationships

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,7 @@ from datacustomcode.client import (
     Client,
     DataCloudAccessLayerException,
     DataCloudObjectType,
+    einstein_predict_col,
     llm_gateway_generate_text_col,
 )
 from datacustomcode.config import (
@@ -16,6 +17,7 @@ from datacustomcode.config import (
     ClientConfig,
     SparkConfig,
 )
+from datacustomcode.einstein_predictions.types import PredictionType
 from datacustomcode.io.reader.base import BaseDataCloudReader
 from datacustomcode.io.writer.base import BaseDataCloudWriter, WriteMode
 
@@ -333,6 +335,94 @@ class TestLLMGatewayGenerateTextCol:
         assert result is sentinel_col
         mock_spark_gateway.llm_gateway_generate_text_col.assert_called_once_with(
             "Greet {name}", values, model_id="m"
+        )
+
+
+class TestClientEinsteinPredict:
+
+    @patch("datacustomcode.client._build_spark_einstein_predictions")
+    def test_forwards_args_to_spark_predictions(self, mock_build, reset_client):
+        mock_predictions = MagicMock()
+        mock_predictions.einstein_predict.return_value = {"results": [1]}
+        mock_build.return_value = mock_predictions
+
+        reader = MagicMock(spec=BaseDataCloudReader)
+        writer = MagicMock(spec=BaseDataCloudWriter)
+        client = Client(reader=reader, writer=writer)
+
+        result = client.einstein_predict(
+            "model1", PredictionType.REGRESSION, {"beds": 3}, settings={"k": 1}
+        )
+
+        assert result == {"results": [1]}
+        mock_predictions.einstein_predict.assert_called_once_with(
+            "model1", PredictionType.REGRESSION, {"beds": 3}, settings={"k": 1}
+        )
+
+    @patch("datacustomcode.client._build_spark_einstein_predictions")
+    def test_predictions_built_lazily_and_cached(self, mock_build, reset_client):
+        mock_predictions = MagicMock()
+        mock_predictions.einstein_predict.return_value = {}
+        mock_build.return_value = mock_predictions
+
+        reader = MagicMock(spec=BaseDataCloudReader)
+        writer = MagicMock(spec=BaseDataCloudWriter)
+        client = Client(reader=reader, writer=writer)
+
+        mock_build.assert_not_called()
+
+        client.einstein_predict("m", PredictionType.REGRESSION, {"a": 1})
+        client.einstein_predict("m", PredictionType.REGRESSION, {"b": 2})
+
+        mock_build.assert_called_once_with()
+        assert mock_predictions.einstein_predict.call_count == 2
+
+    @patch("datacustomcode.client._build_spark_einstein_predictions")
+    def test_uses_injected_spark_predictions_without_config_lookup(
+        self, mock_build, reset_client
+    ):
+        injected = MagicMock()
+        injected.einstein_predict.return_value = {"from": "injected"}
+
+        reader = MagicMock(spec=BaseDataCloudReader)
+        writer = MagicMock(spec=BaseDataCloudWriter)
+        client = Client(
+            reader=reader, writer=writer, spark_einstein_predictions=injected
+        )
+
+        result = client.einstein_predict("m", PredictionType.REGRESSION, {"a": 1})
+
+        assert result == {"from": "injected"}
+        injected.einstein_predict.assert_called_once_with(
+            "m", PredictionType.REGRESSION, {"a": 1}, settings=None
+        )
+        mock_build.assert_not_called()
+
+
+class TestEinsteinPredictCol:
+    """The module-level ``einstein_predict_col`` is a thin wrapper that resolves
+    the client-owned :class:`SparkEinsteinPredictions` and delegates.
+    """
+
+    @patch("datacustomcode.client._build_spark_einstein_predictions")
+    def test_delegates_to_spark_predictions(self, mock_build):
+        mock_predictions = MagicMock()
+        sentinel_col = MagicMock(name="col")
+        mock_predictions.einstein_predict_col.return_value = sentinel_col
+        mock_build.return_value = mock_predictions
+
+        reader = MagicMock(spec=BaseDataCloudReader)
+        writer = MagicMock(spec=BaseDataCloudWriter)
+        Client(reader=reader, writer=writer)
+
+        features = {"beds": MagicMock()}
+        result = einstein_predict_col(
+            "model1", PredictionType.REGRESSION, features, settings={"k": 1}
+        )
+
+        assert result is sentinel_col
+        mock_predictions.einstein_predict_col.assert_called_once_with(
+            "model1", PredictionType.REGRESSION, features, settings={"k": 1}
         )
 
 

--- a/tests/test_einstein_predictions_config_update.py
+++ b/tests/test_einstein_predictions_config_update.py
@@ -19,9 +19,14 @@ import tempfile
 import yaml
 
 from datacustomcode.einstein_predictions.impl.default import DefaultEinsteinPredictions
+from datacustomcode.einstein_predictions.spark_default import (
+    DefaultSparkEinsteinPredictions,
+)
 from datacustomcode.einstein_predictions_config import (
     EinsteinPredictionsConfig,
     EinsteinPredictionsObjectConfig,
+    SparkEinsteinPredictionsConfig,
+    SparkEinsteinPredictionsObjectConfig,
 )
 
 
@@ -95,5 +100,78 @@ class TestEinsteinPredictionsConfigLoad:
             einstein_predictions = config.einstein_predictions_config.to_object()
             assert einstein_predictions is not None
             assert isinstance(einstein_predictions, DefaultEinsteinPredictions)
+        finally:
+            os.unlink(temp_file)
+
+
+class TestSparkEinsteinPredictionsConfigUpdate:
+    def test_update_replaces_config_without_force(self):
+        config1 = SparkEinsteinPredictionsConfig(
+            spark_einstein_predictions_config=SparkEinsteinPredictionsObjectConfig(
+                type_config_name="OldImplementation", options={"old": True}
+            )
+        )
+
+        config2 = SparkEinsteinPredictionsConfig(
+            spark_einstein_predictions_config=SparkEinsteinPredictionsObjectConfig(
+                type_config_name="NewImplementation", options={"new": True}
+            )
+        )
+
+        config1.update(config2)
+
+        assert (
+            config1.spark_einstein_predictions_config.type_config_name
+            == "NewImplementation"
+        )
+
+    def test_update_respects_force_flag(self):
+        config1 = SparkEinsteinPredictionsConfig(
+            spark_einstein_predictions_config=SparkEinsteinPredictionsObjectConfig(
+                type_config_name="ForcedImplementation",
+                options={"forced": True},
+                force=True,
+            )
+        )
+
+        config2 = SparkEinsteinPredictionsConfig(
+            spark_einstein_predictions_config=SparkEinsteinPredictionsObjectConfig(
+                type_config_name="NewImplementation", options={"new": True}
+            )
+        )
+
+        config1.update(config2)
+
+        assert (
+            config1.spark_einstein_predictions_config.type_config_name
+            == "ForcedImplementation"
+        )
+        assert config1.spark_einstein_predictions_config.force is True
+
+
+class TestSparkEinsteinPredictionsConfigLoad:
+    def test_load_from_yaml_file(self):
+        config_data = {
+            "spark_einstein_predictions_config": {
+                "type_config_name": "DefaultSparkEinsteinPredictions"
+            }
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config_data, f)
+            temp_file = f.name
+
+        try:
+            config = SparkEinsteinPredictionsConfig()
+            config.load(temp_file)
+
+            assert config.spark_einstein_predictions_config is not None
+            assert (
+                config.spark_einstein_predictions_config.type_config_name
+                == "DefaultSparkEinsteinPredictions"
+            )
+            spark_predictions = config.spark_einstein_predictions_config.to_object()
+            assert spark_predictions is not None
+            assert isinstance(spark_predictions, DefaultSparkEinsteinPredictions)
         finally:
             os.unlink(temp_file)

--- a/tests/test_spark_einstein_predictions.py
+++ b/tests/test_spark_einstein_predictions.py
@@ -17,10 +17,7 @@ from datacustomcode.einstein_predictions.spark_default import (
     _invoke_predictions,
     _invoke_predictions_as_struct,
 )
-from datacustomcode.einstein_predictions.types import (
-    PredictionResponse,
-    PredictionType,
-)
+from datacustomcode.einstein_predictions.types import PredictionResponse, PredictionType
 
 
 def _success_response(data: dict | None = None) -> PredictionResponse:
@@ -76,7 +73,7 @@ class TestBuildUnderlyingPredictions:
             )
 
             assert _build_underlying_predictions() is mock_predictions
-            mock_obj_config.einstein_predictions_config.to_object.assert_called_once_with()  # noqa: E501
+            mock_obj_config.einstein_predictions_config.to_object.assert_called_once_with()
 
     def test_raises_when_config_missing(self):
         with patch(

--- a/tests/test_spark_einstein_predictions.py
+++ b/tests/test_spark_einstein_predictions.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datacustomcode.einstein_predictions import (
+    DefaultSparkEinsteinPredictions,
+    EinsteinPredictionsCallError,
+)
+from datacustomcode.einstein_predictions.spark_default import (
+    _STATUS_ERROR,
+    _STATUS_SUCCESS,
+    _build_underlying_predictions,
+    _feature_to_prediction_column,
+    _invoke_predictions,
+    _invoke_predictions_as_struct,
+)
+from datacustomcode.einstein_predictions.types import (
+    PredictionResponse,
+    PredictionType,
+)
+
+
+def _success_response(data: dict | None = None) -> PredictionResponse:
+    return PredictionResponse(
+        prediction_type=PredictionType.REGRESSION,
+        status_code=200,
+        data=data if data is not None else {"results": [{"predictedValue": 42.5}]},
+    )
+
+
+def _error_response(
+    status_code: int = 500, error_code: str = "INTERNAL_ERROR"
+) -> PredictionResponse:
+    return PredictionResponse(
+        prediction_type=PredictionType.REGRESSION,
+        status_code=status_code,
+        data={"errorCode": error_code},
+    )
+
+
+class TestDefaultSparkEinsteinPredictionsConstruction:
+    """Construction wires an underlying ``EinsteinPredictions``."""
+
+    def test_uses_injected_predictions_when_provided(self):
+        injected = MagicMock()
+        predictions = DefaultSparkEinsteinPredictions(einstein_predictions=injected)
+        assert predictions._einstein_predictions is injected
+
+    @patch(
+        "datacustomcode.einstein_predictions.spark_default."
+        "_build_underlying_predictions"
+    )
+    def test_falls_back_to_config_when_none_injected(self, mock_build):
+        config_built = MagicMock()
+        mock_build.return_value = config_built
+
+        predictions = DefaultSparkEinsteinPredictions()
+
+        mock_build.assert_called_once_with()
+        assert predictions._einstein_predictions is config_built
+
+
+class TestBuildUnderlyingPredictions:
+    """``_build_underlying_predictions`` resolves the config-defined resource."""
+
+    def test_returns_object_from_config(self):
+        with patch(
+            "datacustomcode.einstein_predictions_config.einstein_predictions_config"
+        ) as mock_obj_config:
+            mock_predictions = MagicMock()
+            mock_obj_config.einstein_predictions_config.to_object.return_value = (
+                mock_predictions
+            )
+
+            assert _build_underlying_predictions() is mock_predictions
+            mock_obj_config.einstein_predictions_config.to_object.assert_called_once_with()  # noqa: E501
+
+    def test_raises_when_config_missing(self):
+        with patch(
+            "datacustomcode.einstein_predictions_config.einstein_predictions_config"
+        ) as mock_obj_config:
+            mock_obj_config.einstein_predictions_config = None
+            with pytest.raises(RuntimeError, match="einstein_predictions_config"):
+                _build_underlying_predictions()
+
+
+class TestFeatureToPredictionColumn:
+    """Python scalar types map to the matching prediction column value type."""
+
+    def test_bool_maps_to_boolean_values(self):
+        col = _feature_to_prediction_column("flag", True)
+        assert col.boolean_values == [True]
+        assert col.double_values is None
+        assert col.string_values is None
+
+    def test_int_maps_to_double_values(self):
+        col = _feature_to_prediction_column("count", 3)
+        assert col.double_values == [3.0]
+
+    def test_float_maps_to_double_values(self):
+        col = _feature_to_prediction_column("amount", 2.5)
+        assert col.double_values == [2.5]
+
+    def test_str_maps_to_string_values(self):
+        col = _feature_to_prediction_column("name", "Ada")
+        assert col.string_values == ["Ada"]
+
+
+class TestDefaultSparkEinsteinPredictionsPredict:
+
+    def test_forwards_model_and_features(self):
+        mock_inner = MagicMock()
+        mock_inner.predict.return_value = _success_response({"results": [1]})
+        predictions = DefaultSparkEinsteinPredictions(einstein_predictions=mock_inner)
+
+        result = predictions.einstein_predict(
+            "model1", PredictionType.REGRESSION, {"beds": 3, "city": "SF"}
+        )
+
+        assert result == {"results": [1]}
+        sent = mock_inner.predict.call_args.args[0]
+        assert sent.model_api_name == "model1"
+        assert sent.prediction_type == PredictionType.REGRESSION
+        column_names = {c.column_name for c in sent.prediction_columns}
+        assert column_names == {"beds", "city"}
+
+    def test_forwards_settings(self):
+        mock_inner = MagicMock()
+        mock_inner.predict.return_value = _success_response()
+        predictions = DefaultSparkEinsteinPredictions(einstein_predictions=mock_inner)
+
+        predictions.einstein_predict(
+            "model1",
+            PredictionType.CLUSTERING,
+            {"x": 1.0},
+            settings={"maxTopContributors": 20},
+        )
+
+        sent = mock_inner.predict.call_args.args[0]
+        assert sent.settings == {"maxTopContributors": 20}
+
+
+class TestDefaultSparkEinsteinPredictionsPredictCol:
+
+    @patch("pyspark.sql.functions.udf")
+    @patch("pyspark.sql.functions.struct")
+    def test_dict_features_built_into_struct_and_wrapped_in_udf(
+        self, mock_struct, mock_udf
+    ):
+        sentinel_struct_col = MagicMock(name="struct_col")
+        mock_struct.return_value = sentinel_struct_col
+        sentinel_udf = MagicMock(name="udf")
+        sentinel_applied = MagicMock(name="udf_applied")
+        sentinel_udf.return_value = sentinel_applied
+        mock_udf.return_value = sentinel_udf
+
+        mock_inner = MagicMock()
+        mock_inner.predict.return_value = _success_response({"results": [7]})
+        predictions = DefaultSparkEinsteinPredictions(einstein_predictions=mock_inner)
+
+        beds_col, baths_col = MagicMock(name="beds"), MagicMock(name="baths")
+        beds_aliased, baths_aliased = (
+            MagicMock(name="beds_aliased"),
+            MagicMock(name="baths_aliased"),
+        )
+        beds_col.alias.return_value = beds_aliased
+        baths_col.alias.return_value = baths_aliased
+
+        result = predictions.einstein_predict_col(
+            "model1",
+            PredictionType.REGRESSION,
+            {"beds": beds_col, "baths": baths_col},
+        )
+
+        beds_col.alias.assert_called_once_with("beds")
+        baths_col.alias.assert_called_once_with("baths")
+        mock_struct.assert_called_once_with(beds_aliased, baths_aliased)
+        mock_udf.assert_called_once()
+        sentinel_udf.assert_called_once_with(sentinel_struct_col)
+        assert result is sentinel_applied
+
+        udf_fn = mock_udf.call_args.args[0]
+        row = MagicMock()
+        row.asDict.return_value = {"beds": 3.0, "baths": 2.0}
+        out = udf_fn(row)
+
+        assert out["status"] == _STATUS_SUCCESS
+        assert json.loads(out["response"]) == {"results": [7]}
+        assert out["error_code"] is None
+        sent = mock_inner.predict.call_args.args[0]
+        assert sent.model_api_name == "model1"
+
+    @patch("pyspark.sql.functions.udf")
+    @patch("pyspark.sql.functions.struct")
+    def test_udf_returns_error_struct_for_null_row(self, mock_struct, mock_udf):
+        mock_struct.return_value = MagicMock()
+        mock_udf.return_value = MagicMock()
+        mock_inner = MagicMock()
+        predictions = DefaultSparkEinsteinPredictions(einstein_predictions=mock_inner)
+
+        predictions.einstein_predict_col(
+            "model1", PredictionType.REGRESSION, {"beds": MagicMock()}
+        )
+
+        udf_fn = mock_udf.call_args.args[0]
+        out = udf_fn(None)
+        assert out["status"] == _STATUS_ERROR
+        assert out["response"] is None
+        assert "null" in out["error_message"].lower()
+        mock_inner.predict.assert_not_called()
+
+    @patch("pyspark.sql.functions.udf")
+    @patch("pyspark.sql.functions.struct")
+    def test_udf_returns_error_struct_on_http_error(self, mock_struct, mock_udf):
+        """Per-row errors are returned as ``status="ERROR"`` structs so one bad
+        row does not abort the Spark job."""
+        mock_struct.return_value = MagicMock()
+        mock_udf.return_value = MagicMock()
+        mock_inner = MagicMock()
+        mock_inner.predict.return_value = _error_response(
+            status_code=503, error_code="UNAVAILABLE"
+        )
+        predictions = DefaultSparkEinsteinPredictions(einstein_predictions=mock_inner)
+
+        predictions.einstein_predict_col(
+            "model1", PredictionType.REGRESSION, {"beds": MagicMock()}
+        )
+
+        udf_fn = mock_udf.call_args.args[0]
+        row = MagicMock()
+        row.asDict.return_value = {"beds": 3.0}
+        out = udf_fn(row)
+
+        assert out["status"] == _STATUS_ERROR
+        assert out["response"] is None
+        assert out["error_code"] == "UNAVAILABLE"
+        assert out["error_message"] is not None
+
+
+class TestInvokePredictions:
+
+    def test_returns_response_data(self):
+        mock_inner = MagicMock()
+        mock_inner.predict.return_value = _success_response({"results": [1]})
+
+        out = _invoke_predictions(
+            mock_inner, "model", PredictionType.REGRESSION, {"x": 1.0}, None
+        )
+        assert out == {"results": [1]}
+
+    def test_raises_call_error_on_error_response(self):
+        mock_inner = MagicMock()
+        mock_inner.predict.return_value = _error_response(
+            status_code=503, error_code="UNAVAILABLE"
+        )
+
+        with pytest.raises(EinsteinPredictionsCallError) as excinfo:
+            _invoke_predictions(
+                mock_inner, "model", PredictionType.REGRESSION, {"x": 1.0}, None
+            )
+
+        assert excinfo.value.status == 503
+        assert excinfo.value.error_code == "UNAVAILABLE"
+        assert "503" in str(excinfo.value)
+        assert "UNAVAILABLE" in str(excinfo.value)
+
+
+class TestInvokePredictionsAsStruct:
+    """Non-raising variant used by the per-row UDF. Both SUCCESS and ERROR
+    cases land in the same struct shape so callers can select fields
+    uniformly."""
+
+    def test_success_returns_success_struct(self):
+        mock_inner = MagicMock()
+        mock_inner.predict.return_value = _success_response({"results": [9]})
+
+        out = _invoke_predictions_as_struct(
+            mock_inner, "model", PredictionType.REGRESSION, {"x": 1.0}, None
+        )
+
+        assert out["status"] == _STATUS_SUCCESS
+        assert json.loads(out["response"]) == {"results": [9]}
+        assert out["error_code"] is None
+        assert out["error_message"] is None
+
+    def test_error_returns_error_struct_without_raising(self):
+        mock_inner = MagicMock()
+        mock_inner.predict.return_value = _error_response(
+            status_code=503, error_code="UNAVAILABLE"
+        )
+
+        out = _invoke_predictions_as_struct(
+            mock_inner, "model", PredictionType.REGRESSION, {"x": 1.0}, None
+        )
+
+        assert out["status"] == _STATUS_ERROR
+        assert out["response"] is None
+        assert out["error_code"] == "UNAVAILABLE"
+        assert out["error_message"] is not None
+
+
+class TestDefaultSparkEinsteinPredictionsErrorHandling:
+    """The scalar einstein_predict path raises when the underlying resource
+    errors."""
+
+    def test_raises_on_error_response(self):
+        mock_inner = MagicMock()
+        mock_inner.predict.return_value = _error_response(
+            status_code=429, error_code="RATE_LIMITED"
+        )
+        predictions = DefaultSparkEinsteinPredictions(einstein_predictions=mock_inner)
+
+        with pytest.raises(EinsteinPredictionsCallError) as excinfo:
+            predictions.einstein_predict(
+                "model1", PredictionType.REGRESSION, {"x": 1.0}
+            )
+
+        assert excinfo.value.status == 429
+        assert excinfo.value.error_code == "RATE_LIMITED"


### PR DESCRIPTION
Following the design pattern used for llm gateway generate text (PR #105), add Einstein predict support to the public SDK Script API in two flavors:

1. One-shot scalar method: Client.einstein_predict(...) returns the prediction response payload as a dict.
2. Per-row column method: einstein_predict_col(...) builds a Spark Column that invokes predict per row and yields a struct {status, response, error_code, error_message}, so a single failing row does not abort the Spark job. response carries the prediction payload as a JSON string.

Both wrap the existing DefaultEinsteinPredictions resource, which calls SFAP over HTTP/REST when testing outside Data Cloud.

- Add SparkEinsteinPredictions base + DefaultSparkEinsteinPredictions impl
- Add EinsteinPredictionsCallError
- Add SparkEinsteinPredictionsConfig + config.yaml wiring
- Wire Client scalar/column methods and top-level exports
- Update README and script template with usage examples
- Add unit tests