### PR TITLE
Increase sf CLI timeout from 30s to 120s

### DIFF
--- a/src/datacustomcode/token_provider.py
+++ b/src/datacustomcode/token_provider.py
@@ -108,7 +108,7 @@ class SFCLITokenProvider(TokenProvider):
                     capture_output=True,
                     text=True,
                     check=True,
-                    timeout=30,
+                    timeout=120,
                 )
             except FileNotFoundError as exc:
                 raise RuntimeError(

--- a/tests/io/reader/test_sf_cli.py
+++ b/tests/io/reader/test_sf_cli.py
@@ -99,7 +99,7 @@ class TestGetToken:
             capture_output=True,
             text=True,
             check=True,
-            timeout=30,
+            timeout=120,
         )
         mock_run.assert_any_call(
             [
@@ -114,7 +114,7 @@ class TestGetToken:
             capture_output=True,
             text=True,
             check=True,
-            timeout=30,
+            timeout=120,
         )
 
     def test_file_not_found_raises_runtime_error(self, reader):


### PR DESCRIPTION
### Problem

`sf org display` on sandbox orgs can take 30–60 seconds, causing a `TimeoutExpired` error with the current hardcoded 30-second limit.

### Fix

Increase `timeout=30` to `timeout=120` in `_run_sf_command`. This accommodates slow sandbox connections while still failing fast on genuine hangs.