### PR TITLE
Add column casing hints for lowercase requirement

### DIFF
--- a/src/datacustomcode/__init__.py
+++ b/src/datacustomcode/__init__.py
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datacustomcode.spark.column_hints import install_column_casing_hints
+
+# Friendlier errors for wrong-case column references. Idempotent.
+install_column_casing_hints()
+
 __all__ = [
     "AuthType",
     "Client",

--- a/src/datacustomcode/config.yaml
+++ b/src/datacustomcode/config.yaml
@@ -18,6 +18,8 @@ spark_config:
     spark.submit.deployMode: client
     spark.sql.execution.arrow.pyspark.enabled: 'true'
     spark.driver.extraJavaOptions: -Djava.security.manager=allow
+    # Resolve columns case-sensitively so wrong-case refs fail locally too.
+    spark.sql.caseSensitive: 'true'
 
 einstein_predictions_config:
   type_config_name: DefaultEinsteinPredictions

--- a/src/datacustomcode/spark/column_hints.py
+++ b/src/datacustomcode/spark/column_hints.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2025, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Friendlier errors when a script references a column by the wrong case.
+
+Data Cloud column names are lowercase. A reference using another case (e.g.
+``df["UnitPrice__c"]``) fails to resolve with a generic error. These hooks
+detect when the lowercase form of a referenced name is a real column and
+prepend an explicit hint, keeping the original message:
+
+    Column 'UnitPrice__c' not found. Did you mean 'unitprice__c'?
+    Data Cloud columns must be lowercase.
+
+Two hooks cover all access paths: one for column-resolution errors, and one
+for attribute access (``df.X``), which fails separately. Both only augment an
+error that was already going to be raised, and only for a pure casing mismatch.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Marker on our wrappers so repeated installs never stack.
+_WRAPPED_MARKER = "_datacustomcode_wrapped"
+
+
+def _strip_backticks(name: str) -> str:
+    """Return the bare column name from a Spark identifier token."""
+    name = name.strip()
+    if "." in name:  # drop any table/alias qualifier
+        name = name.split(".")[-1]
+    return name.strip().strip("`")
+
+
+def _casing_hint(bad: str, suggestion: str) -> str:
+    return (
+        f"Column '{bad}' not found. Did you mean '{suggestion}'? "
+        "Data Cloud columns must be lowercase."
+    )
+
+
+def _lowercase_match(bad: str, available: list[str]) -> str | None:
+    """Return the column matching *bad* case-insensitively, else ``None``.
+
+    Returns ``None`` when *bad* is already lowercase, so a real typo is not
+    reported as a casing issue.
+    """
+    if not bad or bad == bad.lower():
+        return None
+    lowered = bad.lower()
+    for col in available:
+        if col.lower() == lowered:
+            return col
+    return None
+
+
+def _install_analysis_exception_hook() -> None:
+    """Add a casing hint to column-resolution errors."""
+    from pyspark.errors.exceptions import captured
+
+    original = captured.convert_exception
+    if getattr(original, _WRAPPED_MARKER, False):
+        return
+
+    def convert_exception_with_hint(e):  # type: ignore[no-untyped-def]
+        exc = original(e)
+        try:
+            error_class = exc.getErrorClass()
+        except Exception:  # pragma: no cover - defensive
+            return exc
+        if not error_class or not error_class.startswith("UNRESOLVED_COLUMN"):
+            return exc
+
+        params = exc.getMessageParameters() or {}
+        bad = _strip_backticks(params.get("objectName", ""))
+        proposal = params.get("proposal", "")
+        available = [
+            _strip_backticks(tok) for tok in proposal.split(",") if tok.strip()
+        ]
+
+        suggestion = _lowercase_match(bad, available)
+        if suggestion is not None:  # prepend hint; keep original detail
+            exc.desc = f"{_casing_hint(bad, suggestion)}\n{exc.desc}"
+        return exc
+
+    setattr(convert_exception_with_hint, _WRAPPED_MARKER, True)
+    captured.convert_exception = convert_exception_with_hint
+
+
+def _install_getattr_hook() -> None:
+    """Add a casing hint to attribute access (``df.X``)."""
+    from pyspark.sql import DataFrame
+
+    original = DataFrame.__getattr__
+    if getattr(original, _WRAPPED_MARKER, False):
+        return
+
+    def __getattr__with_hint(self, name):  # type: ignore[no-untyped-def]
+        try:
+            return original(self, name)
+        except AttributeError as exc:
+            if name.startswith("_"):  # leave dunder/private lookups alone
+                raise
+            suggestion = _lowercase_match(name, list(self.columns))
+            if suggestion is not None:  # prepend hint; keep original text
+                raise AttributeError(
+                    f"{_casing_hint(name, suggestion)}\n{exc}"
+                ) from None
+            raise
+
+    setattr(__getattr__with_hint, _WRAPPED_MARKER, True)
+    DataFrame.__getattr__ = __getattr__with_hint  # type: ignore[assignment]
+
+
+def install_column_casing_hints() -> None:
+    """Install the column-casing hint hooks. Idempotent; never raises."""
+    try:
+        _install_analysis_exception_hook()
+        _install_getattr_hook()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug(f"Could not install column-casing hint hooks: {exc}")

--- a/tests/spark/test_column_hints.py
+++ b/tests/spark/test_column_hints.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2025, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the column-casing hint hooks."""
+from __future__ import annotations
+
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col
+import pytest
+
+from datacustomcode.spark.column_hints import install_column_casing_hints
+
+HINT_FRAGMENT = "Data Cloud columns must be lowercase"
+
+
+@pytest.fixture(scope="module")
+def spark():
+    # Case-sensitive to match the Data Cloud runtime (and config.yaml).
+    session = (
+        SparkSession.builder.master("local[1]")
+        .appName("column-hints-test")
+        .config("spark.ui.enabled", "false")
+        .config("spark.sql.caseSensitive", "true")
+        .getOrCreate()
+    )
+    session.sparkContext.setLogLevel("OFF")
+    install_column_casing_hints()
+    yield session
+    session.stop()
+
+
+@pytest.fixture
+def df(spark):
+    # Schema is lowercase, as Data Cloud / the SDK reader would produce it.
+    return spark.createDataFrame(
+        [(1, 2.0, "x")], schema=["unitprice__c", "qty__c", "name__c"]
+    )
+
+
+# Each case references the PascalCase name "UnitPrice__c" whose lowercase form
+# "unitprice__c" is a real column. All should surface the casing hint.
+ACCESS_PATHS = {
+    "getitem": lambda df: df["UnitPrice__c"],
+    "select_str": lambda df: df.select("UnitPrice__c").collect(),
+    "col_action": lambda df: df.select(col("UnitPrice__c")).collect(),
+    "filter": lambda df: df.filter(col("UnitPrice__c") > 0).collect(),
+    "with_column": lambda df: df.withColumn("x", col("UnitPrice__c")).collect(),
+    "select_expr": lambda df: df.selectExpr("UnitPrice__c + 1").collect(),
+    "getattr": lambda df: df.UnitPrice__c,
+}
+# Note: df.drop("UnitPrice__c") is intentionally omitted — Spark's drop()
+# silently ignores non-matching names and never raises, so there is no error
+# to augment (and no silent data loss risk, since nothing is dropped).
+
+
+@pytest.mark.parametrize("path_name", sorted(ACCESS_PATHS))
+def test_casing_hint_added_for_all_access_paths(df, path_name):
+    access = ACCESS_PATHS[path_name]
+    with pytest.raises(Exception) as excinfo:
+        access(df)
+    message = str(excinfo.value)
+    assert HINT_FRAGMENT in message, f"{path_name!r} did not get a casing hint"
+    assert "UnitPrice__c" in message
+    assert "unitprice__c" in message
+
+
+def test_original_message_preserved(df):
+    """The hint is prepended; Spark's original error detail must remain."""
+    with pytest.raises(Exception) as excinfo:
+        df.select("UnitPrice__c").collect()
+    message = str(excinfo.value)
+    assert HINT_FRAGMENT in message
+    # Spark's own UNRESOLVED_COLUMN text / suggestion list is still present.
+    assert "UNRESOLVED_COLUMN" in message or "cannot be resolved" in message
+
+
+def test_genuinely_missing_column_is_not_relabelled(df):
+    """A column with no lowercase match keeps the vanilla Spark message."""
+    with pytest.raises(Exception) as excinfo:
+        df.select("TotallyMissing").collect()
+    assert HINT_FRAGMENT not in str(excinfo.value)
+
+
+def test_already_lowercase_missing_column_no_hint(df):
+    """A lowercase typo is a real error, not a casing issue — no hint."""
+    with pytest.raises(Exception) as excinfo:
+        df.select("nonexistent__c").collect()
+    assert HINT_FRAGMENT not in str(excinfo.value)
+
+
+def test_getattr_missing_no_match_keeps_attribute_error(df):
+    """Attribute access for a truly-absent name still raises AttributeError."""
+    with pytest.raises(AttributeError):
+        getattr(df, "NoSuchThing")
+
+
+def test_install_is_idempotent():
+    """Repeated installs must not stack wrappers."""
+    from pyspark.errors.exceptions import captured
+    from pyspark.sql import DataFrame
+
+    install_column_casing_hints()
+    conv1 = captured.convert_exception
+    getattr1 = DataFrame.__getattr__
+    install_column_casing_hints()
+    assert captured.convert_exception is conv1
+    assert DataFrame.__getattr__ is getattr1


### PR DESCRIPTION
As you can see in files changed, I decided to provide our hint (about casing) **as well the original error**:

```
File "/Users/.../datacloud-customcode-python-sdk/.venv20260818/lib/python3.11/site-packages/pyspark/errors/exceptions/captured.py", line 185, in deco
    raise converted from None
pyspark.errors.exceptions.captured.AnalysisException: Column 'Title__c' not found. Did you mean 'title__c'? Data Cloud columns must be lowercase.
[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column or function parameter with name `Title__c` cannot be resolved. Did you mean one of the following? [`title__c`, `id__c`, `name__c`, `kq_id__c`, `industry__c`].;
'Project [cdp_sys_sourceversion__c#0, title__c#1, datasource__c#2, datasourceobject__c#3, name__c#4, industry__c#5, kq_id__c#6, id__c#7, internalorganization__c#8, lower(trim('Title__c, None)) AS Title__c__key#43]
+- LocalRelation [cdp_sys_sourceversion__c#0, title__c#1, datasource__c#2, datasourceobject__c#3, name__c#4, industry__c#5, kq_id__c#6, id__c#7, internalorganization__c#8]
```

Notice this line: **Column 'Title__c' not found. Did you mean 'title__c'? Data Cloud columns must be lowercase.**