### PR TITLE
Fix PermissionError on datacustomcode zip temp directory cleanup

### DIFF
--- a/src/datacustomcode/deploy.py
+++ b/src/datacustomcode/deploy.py
@@ -251,11 +251,8 @@ def prepare_dependency_archive(
         cmd = docker_build_cmd(docker_network)
         cmd_output(cmd, env=docker_env)
 
-    # ignore_cleanup_errors=True: on Windows, Docker creates files inside the
-    # mounted volume whose permissions prevent the host from deleting them.
-    # The archive has already been copied out, so silently skipping leftover
-    # files is safe and avoids a fatal error on context-manager exit.
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+    temp_dir = tempfile.mkdtemp()
+    try:
         logger.info(
             f"Building dependencies archive with docker network: {docker_network}"
         )
@@ -285,6 +282,14 @@ def prepare_dependency_archive(
             os.makedirs(os.path.dirname(DEPENDENCIES_ARCHIVE_PATH), exist_ok=True)
             shutil.copy(archives_temp_path, DEPENDENCIES_ARCHIVE_PATH)
             logger.info(f"Dependencies archived to {DEPENDENCIES_ARCHIVE_PATH}")
+    finally:
+        try:
+            shutil.rmtree(temp_dir)
+        except PermissionError:
+            logger.debug(
+                f"Could not fully remove temp dir {temp_dir}; "
+                "root-owned files from Docker may remain until next reboot."
+            )
 
 
 def docker_build_cmd(network: str) -> str:

--- a/src/datacustomcode/templates/function/build_native_dependencies.sh
+++ b/src/datacustomcode/templates/function/build_native_dependencies.sh
@@ -6,3 +6,7 @@ set -e
 python3.11 -m venv --copies .venv
 source .venv/bin/activate
 pip install --target ./py-files -r requirements.txt
+
+# Reset file ownership within workspace folder
+# to match host user
+chown -R "$(stat -c '%u:%g' /workspace)" /workspace

--- a/src/datacustomcode/templates/script/build_native_dependencies.sh
+++ b/src/datacustomcode/templates/script/build_native_dependencies.sh
@@ -7,3 +7,7 @@ python3.11 -m venv --copies .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 venv-pack -o native_dependencies.tar.gz -f
+
+# Reset file ownership within workspace folder
+# to match host user
+chown -R "$(stat -c '%u:%g' /workspace)" /workspace

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -60,7 +60,8 @@ class TestPrepareDependencyArchive:
 
     @patch("datacustomcode.deploy.cmd_output")
     @patch("datacustomcode.deploy.shutil.copy")
-    @patch("datacustomcode.deploy.tempfile.TemporaryDirectory")
+    @patch("datacustomcode.deploy.shutil.rmtree")
+    @patch("datacustomcode.deploy.tempfile.mkdtemp")
     @patch("datacustomcode.deploy.os.path.join")
     @patch("datacustomcode.deploy.os.makedirs")
     @patch("datacustomcode.deploy.docker_build_cmd")
@@ -71,16 +72,13 @@ class TestPrepareDependencyArchive:
         mock_docker_build_cmd,
         mock_makedirs,
         mock_join,
-        mock_temp_dir,
+        mock_mkdtemp,
+        mock_rmtree,
         mock_copy,
         mock_cmd_output,
     ):
         """Test prepare_dependency_archive when Docker image already exists."""
-        # Mock the temporary directory context manager
-        mock_temp_dir_instance = MagicMock()
-        mock_temp_dir_instance.__enter__.return_value = "/tmp/test_dir"
-        mock_temp_dir_instance.__exit__.return_value = None
-        mock_temp_dir.return_value = mock_temp_dir_instance
+        mock_mkdtemp.return_value = "/tmp/test_dir"
 
         # Mock cmd_output to return image ID (indicating image exists)
         mock_cmd_output.return_value = "abc123"
@@ -117,9 +115,13 @@ class TestPrepareDependencyArchive:
             "payload/archives/native_dependencies.tar.gz",
         )
 
+        # Verify cleanup was attempted
+        mock_rmtree.assert_called_once_with("/tmp/test_dir")
+
     @patch("datacustomcode.deploy.cmd_output")
     @patch("datacustomcode.deploy.shutil.copy")
-    @patch("datacustomcode.deploy.tempfile.TemporaryDirectory")
+    @patch("datacustomcode.deploy.shutil.rmtree")
+    @patch("datacustomcode.deploy.tempfile.mkdtemp")
     @patch("datacustomcode.deploy.os.path.join")
     @patch("datacustomcode.deploy.os.makedirs")
     @patch("datacustomcode.deploy.docker_build_cmd")
@@ -130,16 +132,13 @@ class TestPrepareDependencyArchive:
         mock_docker_build_cmd,
         mock_makedirs,
         mock_join,
-        mock_temp_dir,
+        mock_mkdtemp,
+        mock_rmtree,
         mock_copy,
         mock_cmd_output,
     ):
         """Test prepare_dependency_archive when Docker image needs to be built."""
-        # Mock the temporary directory context manager
-        mock_temp_dir_instance = MagicMock()
-        mock_temp_dir_instance.__enter__.return_value = "/tmp/test_dir"
-        mock_temp_dir_instance.__exit__.return_value = None
-        mock_temp_dir.return_value = mock_temp_dir_instance
+        mock_mkdtemp.return_value = "/tmp/test_dir"
 
         # Mock cmd_output to return None for image check (image doesn't exist)
         # and then return some value for subsequent calls
@@ -178,9 +177,13 @@ class TestPrepareDependencyArchive:
             "payload/archives/native_dependencies.tar.gz",
         )
 
+        # Verify cleanup was attempted
+        mock_rmtree.assert_called_once_with("/tmp/test_dir")
+
     @patch("datacustomcode.deploy.cmd_output")
     @patch("datacustomcode.deploy.shutil.copy")
-    @patch("datacustomcode.deploy.tempfile.TemporaryDirectory")
+    @patch("datacustomcode.deploy.shutil.rmtree")
+    @patch("datacustomcode.deploy.tempfile.mkdtemp")
     @patch("datacustomcode.deploy.os.path.join")
     @patch("datacustomcode.deploy.os.makedirs")
     @patch("datacustomcode.deploy.docker_build_cmd")
@@ -191,16 +194,13 @@ class TestPrepareDependencyArchive:
         mock_docker_build_cmd,
         mock_makedirs,
         mock_join,
-        mock_temp_dir,
+        mock_mkdtemp,
+        mock_rmtree,
         mock_copy,
         mock_cmd_output,
     ):
         """Test prepare_dependency_archive when Docker build fails."""
-        # Mock the temporary directory context manager
-        mock_temp_dir_instance = MagicMock()
-        mock_temp_dir_instance.__enter__.return_value = "/tmp/test_dir"
-        mock_temp_dir_instance.__exit__.return_value = None
-        mock_temp_dir.return_value = mock_temp_dir_instance
+        mock_mkdtemp.return_value = "/tmp/test_dir"
 
         # Mock cmd_output to return None for image check, then raise exception for build
         from datacustomcode.cmd import CalledProcessError
@@ -221,9 +221,13 @@ class TestPrepareDependencyArchive:
         # Verify docker build command was called
         mock_docker_build_cmd.assert_called_once_with("default")
 
+        # Build fails before mkdtemp() is called, so no cleanup needed
+        mock_rmtree.assert_not_called()
+
     @patch("datacustomcode.deploy.cmd_output")
     @patch("datacustomcode.deploy.shutil.copy")
-    @patch("datacustomcode.deploy.tempfile.TemporaryDirectory")
+    @patch("datacustomcode.deploy.shutil.rmtree")
+    @patch("datacustomcode.deploy.tempfile.mkdtemp")
     @patch("datacustomcode.deploy.os.path.join")
     @patch("datacustomcode.deploy.os.makedirs")
     @patch("datacustomcode.deploy.docker_build_cmd")
@@ -234,16 +238,13 @@ class TestPrepareDependencyArchive:
         mock_docker_build_cmd,
         mock_makedirs,
         mock_join,
-        mock_temp_dir,
+        mock_mkdtemp,
+        mock_rmtree,
         mock_copy,
         mock_cmd_output,
     ):
         """Test prepare_dependency_archive when Docker run fails."""
-        # Mock the temporary directory context manager
-        mock_temp_dir_instance = MagicMock()
-        mock_temp_dir_instance.__enter__.return_value = "/tmp/test_dir"
-        mock_temp_dir_instance.__exit__.return_value = None
-        mock_temp_dir.return_value = mock_temp_dir_instance
+        mock_mkdtemp.return_value = "/tmp/test_dir"
 
         # Mock cmd_output to return image ID, then raise exception for run
         from datacustomcode.cmd import CalledProcessError
@@ -268,9 +269,13 @@ class TestPrepareDependencyArchive:
         # Verify docker run command was called
         mock_docker_run_cmd.assert_called_once_with("default", "/tmp/test_dir")
 
+        # Verify cleanup was still attempted (in finally block)
+        mock_rmtree.assert_called_once_with("/tmp/test_dir")
+
     @patch("datacustomcode.deploy.cmd_output")
     @patch("datacustomcode.deploy.shutil.copy")
-    @patch("datacustomcode.deploy.tempfile.TemporaryDirectory")
+    @patch("datacustomcode.deploy.shutil.rmtree")
+    @patch("datacustomcode.deploy.tempfile.mkdtemp")
     @patch("datacustomcode.deploy.os.path.join")
     @patch("datacustomcode.deploy.os.makedirs")
     @patch("datacustomcode.deploy.docker_build_cmd")
@@ -281,16 +286,13 @@ class TestPrepareDependencyArchive:
         mock_docker_build_cmd,
         mock_makedirs,
         mock_join,
-        mock_temp_dir,
+        mock_mkdtemp,
+        mock_rmtree,
         mock_copy,
         mock_cmd_output,
     ):
         """Test prepare_dependency_archive when file copy fails."""
-        # Mock the temporary directory context manager
-        mock_temp_dir_instance = MagicMock()
-        mock_temp_dir_instance.__enter__.return_value = "/tmp/test_dir"
-        mock_temp_dir_instance.__exit__.return_value = None
-        mock_temp_dir.return_value = mock_temp_dir_instance
+        mock_mkdtemp.return_value = "/tmp/test_dir"
 
         # Mock cmd_output to return image ID
         mock_cmd_output.return_value = "abc123"
@@ -307,11 +309,14 @@ class TestPrepareDependencyArchive:
         # Verify files were attempted to be copied
         mock_copy.assert_any_call("requirements.txt", "/tmp/test_dir")
 
+        # Verify cleanup was still attempted (in finally block)
+        mock_rmtree.assert_called_once_with("/tmp/test_dir")
+
     @patch("datacustomcode.deploy.cmd_output")
     @patch("datacustomcode.deploy.shutil.copytree")
     @patch("datacustomcode.deploy.shutil.rmtree")
     @patch("datacustomcode.deploy.shutil.copy")
-    @patch("datacustomcode.deploy.tempfile.TemporaryDirectory")
+    @patch("datacustomcode.deploy.tempfile.mkdtemp")
     @patch("datacustomcode.deploy.os.path.exists")
     @patch("datacustomcode.deploy.os.path.join")
     @patch("datacustomcode.deploy.os.makedirs")
@@ -324,18 +329,14 @@ class TestPrepareDependencyArchive:
         mock_makedirs,
         mock_join,
         mock_exists,
-        mock_temp_dir,
+        mock_mkdtemp,
         mock_copy,
         mock_rmtree,
         mock_copytree,
         mock_cmd_output,
     ):
         """Test prepare_dependency_archive with function package type."""
-        # Mock the temporary directory context manager
-        mock_temp_dir_instance = MagicMock()
-        mock_temp_dir_instance.__enter__.return_value = "/tmp/test_dir"
-        mock_temp_dir_instance.__exit__.return_value = None
-        mock_temp_dir.return_value = mock_temp_dir_instance
+        mock_mkdtemp.return_value = "/tmp/test_dir"
 
         # Mock cmd_output to return image ID (indicating image exists)
         mock_cmd_output.return_value = "abc123"
@@ -381,8 +382,9 @@ class TestPrepareDependencyArchive:
         # Verify payload directory was created
         mock_makedirs.assert_called_once_with("payload", exist_ok=True)
 
-        # Verify py-files was NOT removed (doesn't exist yet)
-        mock_rmtree.assert_not_called()
+        # Verify cleanup was called only once
+        # (for temp dir, not py-files since it didn't exist)
+        mock_rmtree.assert_called_once_with("/tmp/test_dir")
 
         # Verify py-files directory was copied
         mock_copytree.assert_called_once_with(
@@ -391,7 +393,8 @@ class TestPrepareDependencyArchive:
 
     @patch("datacustomcode.deploy.cmd_output")
     @patch("datacustomcode.deploy.shutil.copy")
-    @patch("datacustomcode.deploy.tempfile.TemporaryDirectory")
+    @patch("datacustomcode.deploy.shutil.rmtree")
+    @patch("datacustomcode.deploy.tempfile.mkdtemp")
     @patch("datacustomcode.deploy.os.path.exists")
     @patch("datacustomcode.deploy.os.path.join")
     @patch("datacustomcode.deploy.os.makedirs")
@@ -404,7 +407,8 @@ class TestPrepareDependencyArchive:
         mock_makedirs,
         mock_join,
         mock_exists,
-        mock_temp_dir,
+        mock_mkdtemp,
+        mock_rmtree,
         mock_copy,
         mock_cmd_output,
     ):
@@ -412,11 +416,7 @@ class TestPrepareDependencyArchive:
         Test prepare_dependency_archive with function type when py-files is missing.
         Should log and continue without error.
         """
-        # Mock the temporary directory context manager
-        mock_temp_dir_instance = MagicMock()
-        mock_temp_dir_instance.__enter__.return_value = "/tmp/test_dir"
-        mock_temp_dir_instance.__exit__.return_value = None
-        mock_temp_dir.return_value = mock_temp_dir_instance
+        mock_mkdtemp.return_value = "/tmp/test_dir"
 
         # Mock cmd_output to return image ID (indicating image exists)
         mock_cmd_output.return_value = "abc123"
@@ -442,6 +442,9 @@ class TestPrepareDependencyArchive:
         # Verify docker commands were called
         mock_cmd_output.assert_any_call(self.EXPECTED_DOCKER_IMAGES_CMD)
         mock_docker_run_cmd.assert_called_once_with("default", "/tmp/test_dir")
+
+        # Verify cleanup was attempted
+        mock_rmtree.assert_called_once_with("/tmp/test_dir")
 
 
 class TestHasNonemptyRequirementsFile:


### PR DESCRIPTION
Summary

- Fix crash when `datacustomcode zip` fails to clean up temp directory containing root-owned files created by Docker on Linux
- Add `chown` to build scripts to reset file ownership before container exits
- Replace `TemporaryDirectory` with `mkdtemp` + graceful `PermissionError` fallback in deploy.py

Context

- On Linux, Docker creates files as root inside mounted volumes. Python 3.10-3.14's `TemporaryDirectory(ignore_cleanup_errors=True)` has a known [bug](https://github.com/python/cpython/issues/135812) where `_resetperms` raises an unhandled `PermissionError` when attempting to `chmod` root-owned directories. The archive is already copied out before cleanup, so the crash occurs after all useful work is done.